### PR TITLE
fix: remove unexpected character in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { decodeResumeToken } from './';
-if (!process.argv[2]?.match(/([A-Z0-9]{2})*/i)) {
+if (!process.argv[2].match(/([A-Z0-9]{2})*/i)) {
   throw new Error('Usage: mongodb-resumetoken-decoder <hex string>');
 }
 console.dir(decodeResumeToken(process.argv[2]), { depth: Infinity, customInspect: true });


### PR DESCRIPTION
# Issue
When decoding MongoDB resume tokens by the following command, I got an "Unexpected token" error. After investigating the codes, I found that there is an unexpected `?` character in CLI. 


```
# Before
npx mongodb-resumetoken-decoder 82612E8513000000012B022C0100296E5A1004A5093ABB38FE4B9EA67F01BB1A96D812463C5F6964003C5F5F5F78000004
/Users/william_luo/node_modules/mongodb-resumetoken-decoder/lib/cli.js:4
if (!process.argv[2]?.match(/([A-Z0-9]{2})*/i)) {
                     ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:1053:16)
    at Module._compile (internal/modules/cjs/loader.js:1101:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Module.require (internal/modules/cjs/loader.js:1025:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/Users/william_luo/node_modules/mongodb-resumetoken-decoder/bin/mongodb-resumetoken-decoder.js:2:1)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
```

After removing this character, everything works well.
```
# After
npx mongodb-resumetoken-decoder 82612E8513000000012B022C0100296E5A1004A5093ABB38FE4B9EA67F01BB1A96D812463C5F6964003C5F5F5F78000004
{
  timestamp: new Timestamp({ t: 1630438675, i: 1 }),
  version: 1,
  tokenType: 128,
  txnOpIndex: 0,
  fromInvalidate: false,
  uuid: new UUID("a5093abb-38fe-4b9e-a67f-01bb1a96d812"),
  documentKey: { _id: '___x' }
}
```

# Fixes 
```
1. remove-unexpected-character-in-cli
```
This PR will fix the above issue, which removing the unexpected character in `cli.ts`.