### PR TITLE
fix: fix behavior for tiny doubles (less than `2**(-255)`)

### DIFF
--- a/src/keystringdecoder.ts
+++ b/src/keystringdecoder.ts
@@ -258,7 +258,7 @@ function readValue(ctype: number, version: KeyStringVersion, buf: BufferConsumer
           encoded -= 1n << 62n;
           encoded >>= 1n;
           const scaledBin = read64BitIEEE754(encoded);
-          const bin = scaledBin * (1 ** -256);
+          const bin = scaledBin * (2 ** -256);
           if (hasDecimalContinuation) { buf.readUint64BE(); }
           return isNegative ? -bin : bin;
         }

--- a/test/index.ts
+++ b/test/index.ts
@@ -139,4 +139,29 @@ describe('decodeResumeToken', function() {
       version: 2
     });
   });
+
+  it('can decode resume tokens with a tiny double in them', () => {
+    const decoded = decodeResumeToken('8265523992000000012B022C0100296E5A1004754B35D306B342E8BA0A3DE71005B66446465F6964004650666F6F0050337F78F63E7958E8661F808709C186A717992A6083F43058818C1A289F7C0BCFA77E73E500000004');
+    assert.deepStrictEqual(decoded, {
+      eventIdentifier: {
+        documentKey: {
+          _id: {
+            foo: [
+              2e+307, 2e+307, 2e-307, 2e-307
+            ]
+          }
+        },
+        operationType: 'insert'
+      },
+      fromInvalidate: false,
+      timestamp: new bson.Timestamp({
+        t: 1651836794,
+        i: 1
+      }),
+      tokenType: 128,
+      txnOpIndex: 0,
+      uuid: new bson.UUID('bffdb617-400e-4860-9900-7c0e0048b305'),
+      version: 2
+    });
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -143,25 +143,22 @@ describe('decodeResumeToken', function() {
   it('can decode resume tokens with a tiny double in them', () => {
     const decoded = decodeResumeToken('8265523992000000012B022C0100296E5A1004754B35D306B342E8BA0A3DE71005B66446465F6964004650666F6F0050337F78F63E7958E8661F808709C186A717992A6083F43058818C1A289F7C0BCFA77E73E500000004');
     assert.deepStrictEqual(decoded, {
-      eventIdentifier: {
-        documentKey: {
-          _id: {
-            foo: [
-              2e+307, 2e+307, 2e-307, 2e-307
-            ]
-          }
-        },
-        operationType: 'insert'
+      documentKey: {
+        _id: {
+          foo: [
+            2e+307, -2e+307, 2e-307, -2e-307
+          ]
+        }
       },
       fromInvalidate: false,
       timestamp: new bson.Timestamp({
-        t: 1651836794,
+        t: 1699887506,
         i: 1
       }),
       tokenType: 128,
       txnOpIndex: 0,
-      uuid: new bson.UUID('bffdb617-400e-4860-9900-7c0e0048b305'),
-      version: 2
+      uuid: new bson.UUID('754b35d3-06b3-42e8-ba0a-3de71005b664'),
+      version: 1
     });
   });
 });


### PR DESCRIPTION
Original C++ source:
https://github.com/mongodb/mongo/blob/6e34f5094204aaf9bf14b51252ab347b4035b584/src/mongo/db/storage/key_string.cpp#L1658 https://github.com/mongodb/mongo/blob/6e34f5094204aaf9bf14b51252ab347b4035b584/src/mongo/db/storage/key_string.cpp#L194

`ldexp(1, b)` is `2**b`, not `1**b` (d'uh).