### PR TITLE
fix: export type definitions for >= ts-4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,18 @@
     "mongodb-resumetoken-decoder": "bin/mongodb-resumetoken-decoder.js"
   },
   "exports": {
-    "require": "./lib/index.js",
-    "import": "./.esm-wrapper.mjs"
+    ".": {
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./.esm-wrapper.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
   },
+  "types": "./lib/index.d.ts",
   "files": [
     "LICENSE-Community.txt",
     "bin",


### PR DESCRIPTION
When using this library in an ESM project using >= TS-4.7, you get the following error message:

```
TS7016: Could not find a declaration file for module 'mongodb-resumetoken-decoder'. 
'/home/user/project/node_modules/.pnpm/mongodb-resumetoken-decoder@1.1.1/
node_modules/mongodb-resumetoken-decoder/.esm-wrapper.mjs' implicitly has an any type.

There are types at '/home/user/project/node_modules/mongodb-resumetoken-decoder/lib/index.d.ts', 
but this result could not be resolved when respecting package.json exports. 
The 'mongodb-resumetoken-decoder' library may need to update its package.json or typings.
```

For dual CommonJS/ES module packages, >= TS-4.7 requires the types to be declared explicitly on the exports object, since according to the [TS docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing:~:text=Attempting%20to%20use%20a%20single%20.d.ts%20file%20to%20type%20both%20an%20ES%20module%20entrypoint%20and%20a%20CommonJS%20entrypoint%20will%20cause%20TypeScript%20to%20think%20only%20one%20of%20those%20entrypoints%20exists%2C%20causing%20compiler%20errors%20for%20users%20of%20the%20package.): 

> Attempting to use a single .d.ts file to type both an ES module entrypoint and a CommonJS entrypoint will cause TypeScript to think only one of those entrypoints exists, causing compiler errors for users of the package.

This PR updates the exports object on the `package.json` with type declaration exports according to guidelines laid out in the [TS 4.7 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing). 